### PR TITLE
added new twig function html_attr

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,9 @@ This package is a Twig extension that provides the following:
  * [`html_classes`][2] function: returns a string by conditionally joining class
    names together.
 
+ * [`html_attr`][3] function: returns a string by conditionally joining html attributes
+   together.
+
 [1]: https://twig.symfony.com/data_uri
 [2]: https://twig.symfony.com/html_classes
+[3]: https://twig.symfony.com/html_attr

--- a/src/HtmlExtension.php
+++ b/src/HtmlExtension.php
@@ -35,6 +35,7 @@ final class HtmlExtension extends AbstractExtension
     {
         return [
             new TwigFunction('html_classes', 'twig_html_classes'),
+            new TwigFunction('html_attr', [$this, 'twig_html_attributes'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -107,5 +108,23 @@ function twig_html_classes(...$args): string
     }
 
     return implode(' ', array_unique($classes));
+}
+
+function twig_html_attributes(array $attributes): string
+{
+    $output = '';
+
+    foreach ($attributes as $attribute => $value) {
+        if ($value === true) {
+            $output .= ' ' . $attribute;
+        } else if (\is_string($value) || \is_numeric($value)) {
+            $value = \htmlspecialchars($value, ENT_COMPAT | ENT_HTML5, 'UTF-8', false);
+            $output .= sprintf(' %s="%s"', $attribute, $value);
+        } else if ($value !== false) {
+            throw new RuntimeError(sprintf('The html_attr function argument value of key %d should be either a boolean, string or number, got "%s".', $attribute, \gettype($value)));
+        }
+    }
+
+    return $output;
 }
 }

--- a/src/HtmlExtension.php
+++ b/src/HtmlExtension.php
@@ -35,7 +35,7 @@ final class HtmlExtension extends AbstractExtension
     {
         return [
             new TwigFunction('html_classes', 'twig_html_classes'),
-            new TwigFunction('html_attr', [$this, 'twig_html_attributes'], ['is_safe' => ['html']]),
+            new TwigFunction('html_attr', 'twig_html_attributes', ['is_safe' => ['html']]),
         ];
     }
 

--- a/tests/Fixtures/html_attr.test
+++ b/tests/Fixtures/html_attr.test
@@ -1,0 +1,15 @@
+--TEST--
+"html_attr" function
+--TEMPLATE--
+{% set attr = {
+        'aria-expandend': 'false',
+        disabled: true,
+        hidden: false,
+        id: 123,
+        title: 'cli"<ck',
+    } %}
+{{ html_attr(attr) }}
+--DATA--
+return []
+--EXPECT--
+ aria-expandend="false" disabled id="123" title="cli&quot;&lt;ck"

--- a/tests/Fixtures/html_attr_with_unsupported_key.test
+++ b/tests/Fixtures/html_attr_with_unsupported_key.test
@@ -1,0 +1,8 @@
+--TEST--
+"html_attr" function
+--TEMPLATE--
+{{ html_attr({ test: { foo: 'bar' }}) }}
+--DATA--
+return []
+--EXCEPTION--
+Twig\Error\RuntimeError: The html_attr function argument value of key 0 should be either a boolean, string or number, got "array" in "index.twig" at line 2.


### PR DESCRIPTION
Hi, I would suggest to add a new helper function to manage html attributes in a simple way.
Of course, the docs page https://twig.symfony.com/html_attr does not exist atm.

twig example:
```
    {% set attr = {
        'aria-expandend': 'false',
        disabled: true,
        hidden: false,
        id: 123,
        title: 'cli"<ck',
    } %}

    <button{{ html_attr(attr) }}>Test</button>
```
output: 
```
<button aria-expandend="false" disabled id="123" title="cli&quot;&lt;ck">Test</button>
```