### PR TITLE
Add "html_attributes" twig filter for easiely write attributes as objects

### DIFF
--- a/HtmlExtension.php
+++ b/HtmlExtension.php
@@ -89,8 +89,10 @@ final class HtmlExtension extends AbstractExtension
         /** @var string[] $htmlAttributes */
         $htmlAttributes = [];
         foreach ($attributes as $key => $value) {
-            if (\is_bool($value) && $value) {
-                $htmlAttributes[] .= $key;
+            if (\is_bool($value)) {
+                if ($value) {
+                    $htmlAttributes[] .= $key;
+                }
 
                 continue;
             }

--- a/HtmlExtension.php
+++ b/HtmlExtension.php
@@ -82,7 +82,7 @@ final class HtmlExtension extends AbstractExtension
     }
 
     /**
-     * @param array{string, string|bool} $attributes
+     * @param array{string, string|bool|null} $attributes
      */
     public function htmlAttributes(array $attributes): string
     {
@@ -98,6 +98,10 @@ final class HtmlExtension extends AbstractExtension
             }
 
             $htmlAttributes[] .= $key . '="' . $value . '"';
+        }
+        
+        if ($value === null) {
+            continue;
         }
 
         return \implode(' ', $htmlAttributes);

--- a/HtmlExtension.php
+++ b/HtmlExtension.php
@@ -28,6 +28,7 @@ final class HtmlExtension extends AbstractExtension
     {
         return [
             new TwigFilter('data_uri', [$this, 'dataUri']),
+            new TwigFilter('html_attributes', [$this, 'htmlAttributes'], ['is_safe' => ['html']]),
         ];
     }
 
@@ -78,6 +79,26 @@ final class HtmlExtension extends AbstractExtension
         }
 
         return $repr;
+    }
+
+    /**
+     * @param array{string, string|bool} $attributes
+     */
+    public function htmlAttributes(array $attributes): string
+    {
+        /** @var string[] $htmlAttributes */
+        $htmlAttributes = [];
+        foreach ($attributes as $key => $value) {
+            if (\is_bool($value) && $value) {
+                $htmlAttributes[] .= $key;
+
+                continue;
+            }
+
+            $htmlAttributes[] .= $key . '="' . $value . '"';
+        }
+
+        return \implode(' ', $htmlAttributes);
     }
 }
 }


### PR DESCRIPTION
Example usage:

```twig
<!-- button.html.twig -->
{# required #}
{%- set text = text -%}

{# optional #}
{%- set id = id|default -%}
{%- set skin = skin|default('primary') -%}
{%- set type = type|default('button') -%}
{%- set disabled = disabled|default -%}

{% set attributes = {
    'id': id,
    'class': html_classes(
        'c-button',
        {
            'c-button--primary': skin == 'primary',
            'c-button--secondary': skin == 'secondary',
            'c-button--borderless': skin == 'borderless',
        },
    ),
    'type': type,
    'disabled': disabled,
} %}

<button {{ attributes|html_attributes }}>
    {{- text -}}
</button>
```

## TODO

 - [ ] Add Test Case
 - [ ] Escape Value