### PR TITLE
CVA function

### DIFF
--- a/CVA.php
+++ b/CVA.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Extra\Html;
+
+/**
+ * @author Mathéo Daninos <matheo.daninos@gmail.com>
+ *
+ * CVA (class variant authority), is a concept from the js world.
+ * https://cva.style/docs
+ * The UI library shadcn is build on top of this principle
+ * https://ui.shadcn.com
+ * The concept behind CVA is to let you build component with a lot of different variations called recipes.
+ *
+ * @experimental
+ */
+final class CVA
+{
+    /**
+     * @var null
+     */
+    private $base;
+
+    /**
+     * @var null
+     */
+    private $variants;
+
+    /**
+     * @var null
+     */
+    private $compounds;
+
+    /**
+     * @var string|null
+     * @var array<string, array<string, string>>|null the array should have the following format [variantCategory => [variantName => classes]]
+     *                                                ex: ['colors' => ['primary' => 'bleu-8000', 'danger' => 'red-800 text-bold'], 'size' => [...]]
+     * @var array<array<string, string[]>>|null       the array should have the following format ['variantsCategory' => ['variantName', 'variantName'], 'class' => 'text-red-500']
+     */
+    public function __construct(
+        $base = null,
+        $variants = null,
+        $compounds = null
+    ) {
+        $this->base = $base;
+        $this->variants = $variants;
+        $this->compounds = $compounds;
+    }
+
+    public function apply(array $recipes, ?string $classes = null): string
+    {
+        return trim($this->resolve($recipes).' '.$classes ?? '');
+    }
+
+    public function resolve(array $recipes): string
+    {
+        $classes = $this->base ?? '';
+
+        foreach ($recipes as $recipeName => $recipeValue) {
+            if (!isset($this->variants[$recipeName][$recipeValue])) {
+                continue;
+            }
+
+            $classes .= ' '.$this->variants[$recipeName][$recipeValue];
+        }
+
+        if (null !== $this->compounds) {
+            foreach ($this->compounds as $compound) {
+                $isCompound = true;
+                foreach ($compound as $compoundName => $compoundValues) {
+                    if ('class' === $compoundName) {
+                        continue;
+                    }
+
+                    if (!isset($recipes[$compoundName])) {
+                        $isCompound = false;
+                        break;
+                    }
+
+                    if (!\in_array($recipes[$compoundName], $compoundValues)) {
+                        $isCompound = false;
+                        break;
+                    }
+                }
+
+                if ($isCompound) {
+                    if (!isset($compound['class']) || !\is_string($compound['class'])) {
+                        throw new \LogicException('A compound recipe matched but no classes are registered for this match');
+                    }
+
+                    $classes .= ' '.$compound['class'];
+                }
+            }
+        }
+
+        return trim($classes);
+    }
+}

--- a/HtmlExtension.php
+++ b/HtmlExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\Mime\MimeTypes;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Twig\Extra\Html\CVA;
 
 final class HtmlExtension extends AbstractExtension
 {
@@ -35,6 +36,7 @@ final class HtmlExtension extends AbstractExtension
     {
         return [
             new TwigFunction('html_classes', 'twig_html_classes'),
+            new TwigFunction('cva', [$this, 'cva'])
         ];
     }
 
@@ -78,6 +80,16 @@ final class HtmlExtension extends AbstractExtension
         }
 
         return $repr;
+    }
+
+    /**
+     * @param string     $base      some base class you want to have in every matching recipes
+     * @param array      $recipe    your recipes class
+     * @param array|null $compounds compounds allow you to add extra class when multiple variation are matching in the same time
+     */
+    public function cva(string $base, array $recipe, ?array $compounds = []): CVA
+    {
+        return new CVA($base, $recipe, $compounds);
     }
 }
 }

--- a/Tests/CVATest.php
+++ b/Tests/CVATest.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Twig\Extra\Html\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Extra\Html\CVA;
+
+/**
+ * @author Mathéo Daninos <matheo.daninos@gmail.com>
+ */
+class CVATest extends TestCase
+{
+    /**
+     * @dataProvider recipeProvider
+     */
+    public function testRecipes(array $recipe, array $recipes, string $expected): void
+    {
+        $recipeClass = new CVA($recipe['base'] ?? '', $recipe['variants'] ?? [], $recipe['compounds'] ?? []);
+
+        $this->assertEquals($expected, $recipeClass->resolve($recipes));
+    }
+
+    public static function recipeProvider(): iterable
+    {
+        yield 'base null' => [
+            ['variants' => [
+                'colors' => [
+                    'primary' => 'text-primary',
+                    'secondary' => 'text-secondary',
+                ],
+                'sizes' => [
+                    'sm' => 'text-sm',
+                    'md' => 'text-md',
+                    'lg' => 'text-lg',
+                ],
+            ]],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'text-primary text-sm',
+        ];
+
+        yield 'base empty' => [
+            [
+                'base' => '',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ]],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'text-primary text-sm',
+        ];
+
+        yield 'no recipes match' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+            ],
+            ['colors' => 'red', 'sizes' => 'test'],
+            'font-semibold border rounded',
+        ];
+
+        yield 'simple variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm',
+        ];
+
+        yield 'simple variants with custom' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+            ],
+            ['colors' => 'secondary', 'sizes' => 'md'],
+            'font-semibold border rounded text-secondary text-md',
+        ];
+
+        yield 'compound variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['primary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm text-red-500',
+        ];
+
+        yield 'multiple compound variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['primary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                    [
+                        'colors' => ['primary'],
+                        'sizes' => ['md'],
+                        'class' => 'text-blue-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm text-red-500',
+        ];
+
+        yield 'compound with multiple variants' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['primary', 'secondary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm text-red-500',
+        ];
+
+        yield 'compound doesn\'t match' => [
+            [
+                'base' => 'font-semibold border rounded',
+                'variants' => [
+                    'colors' => [
+                        'primary' => 'text-primary',
+                        'secondary' => 'text-secondary',
+                    ],
+                    'sizes' => [
+                        'sm' => 'text-sm',
+                        'md' => 'text-md',
+                        'lg' => 'text-lg',
+                    ],
+                ],
+                'compounds' => [
+                    [
+                        'colors' => ['danger', 'secondary'],
+                        'sizes' => ['sm'],
+                        'class' => 'text-red-500',
+                    ],
+                ],
+            ],
+            ['colors' => 'primary', 'sizes' => 'sm'],
+            'font-semibold border rounded text-primary text-sm',
+        ];
+    }
+}

--- a/Tests/Fixtures/cva.test
+++ b/Tests/Fixtures/cva.test
@@ -1,0 +1,18 @@
+--TEST--
+"cva" function
+--TEMPLATE--
+{% set alert = cva('alert', {
+   theme: {
+      primary: 'bg-blue',
+      secondary: 'bg-orange'
+   },
+    size: {
+        small: 'text-sm',
+        large: 'text-lg'
+    }
+}) %}
+{{ alert.apply({theme: 'primary', size: 'large'}) }}
+--DATA--
+return []
+--EXPECT--
+alert bg-blue text-lg


### PR DESCRIPTION
Hey! I first made this PR here: https://github.com/symfony/ux/pull/1416
but @kbond noticed me (https://github.com/symfony/ux/pull/1416#pullrequestreview-1856788980) that the best place to implement this should be on this repo.

Here is the description from the first PR:

This PR introduces a new concept CVA (Class Variance Authority), by adding a1 twig function, to help you manage your class in your component.

Let's take an example an Alert component. In your app, an alert can have a lot of different styles one for success, one for alert, one for warning, and different sizes, with icons or not... You need something that lets you completely change the style of your component without creating a new component, and without creating too much complexity in your template.

Here is the reason came CVA.

Your Alert component can now look like this:

```twig
{% props color = 'blue', size = 'md', class = '' %}

{% set alert =  cva('alert', 'rounded-lg',
    {
        'color': {
            'blue': 'text-blue-800 bg-blue-50 dark:bg-gray-800 dark:text-blue-400',
            'red': 'text-red-800 bg-red-50 dark:bg-gray-800 dark:text-red-400',
            'green': 'text-green-800 bg-green-50 dark:bg-gray-800 dark:text-green-400',
            'yellow': 'text-yellow-800 bg-yellow-50 dark:bg-gray-800 dark:text-yellow-400',
        },
        'size': {
            'sm': 'px-4 py-3 text-sm',
            'md': 'px-6 py-4 text-base',
            'lg': 'px-8 py-5 text-lg',
        }
    }
) %}

<div class="{{ cva.apply({color, size}, class) }}">
    ...
</div>
```

So here you have a `cva` function that lets you define different variants of your component.

You can now use your component like this:
```twig
<twig:Alert color="red" size="md"/>

<twig:Alert color="green" size="sm"/>

<twig:Alert color="yellow" size="lg"/>

<twig:Alert color="red" size="md" class="dark:bg-gray-800"/>
```

And then you get the following result:

<img width="1269" alt="Capture d’écran 2024-01-24 à 00 52 33" src="https://github.com/symfony/ux/assets/32077734/6a5e25be-5b81-4ae7-8385-0fa5422d0396">

If you want to know more about the concept I implement here you can look at:
- CVA (js version): https://cva.style/docs
- tailwind merge: https://github.com/gehrisandro/tailwind-merge-php, https://github.com/dcastil/tailwind-merge
- this implementation by using tailwind-merge and cva is inspired a lot by: https://ui.shadcn.com/ (shadcn is the most starred library on github in 2023) 
- a really good article that explains the philosophy behind https://manupa.dev/blog/anatomy-of-shadcn-ui
- this PR works great in a LASTstack: https://symfonycasts.com/screencast/last-stack/last-stack

Tell me what you think about it! Thanks for your time! Cheers 🧡