### PR TITLE
Add support for `Stringable`

### DIFF
--- a/HtmlExtension.php
+++ b/HtmlExtension.php
@@ -92,20 +92,20 @@ final class HtmlExtension extends AbstractExtension
     {
         $classes = [];
         foreach ($args as $i => $arg) {
-            if (\is_string($arg)) {
-                $classes[] = $arg;
+            if (\is_string($arg) || $arg instanceof \Stringable) {
+                $classes[] = (string) $arg;
             } elseif (\is_array($arg)) {
                 foreach ($arg as $class => $condition) {
-                    if (!\is_string($class)) {
-                        throw new RuntimeError(\sprintf('The "html_classes" function argument %d (key %d) should be a string, got "%s".', $i, $class, get_debug_type($class)));
+                    if (!\is_string($class) && !$class instanceof \Stringable) {
+                        throw new RuntimeError(\sprintf('The "html_classes" function argument %d (key %d) should be a string or an instance of Stringable, got "%s".', $i, $class, get_debug_type($class)));
                     }
                     if (!$condition) {
                         continue;
                     }
-                    $classes[] = $class;
+                    $classes[] = (string) $class;
                 }
             } else {
-                throw new RuntimeError(\sprintf('The "html_classes" function argument %d should be either a string or an array, got "%s".', $i, get_debug_type($arg)));
+                throw new RuntimeError(\sprintf('The "html_classes" function argument %d should be either a string, an instance of Stringable or an array, got "%s".', $i, get_debug_type($arg)));
             }
         }
 

--- a/Tests/Fixtures/html_classes.test
+++ b/Tests/Fixtures/html_classes.test
@@ -4,9 +4,12 @@
 {{ html_classes('a', {'b': true, 'c': false}, 'd', false ? 'e', true ? 'f', '0') }}
 {% set class_a = 'a' %}
 {% set class_b = 'b' %}
-{{ html_classes(class_a, {(class_b): true})}}
+{%- set class_c -%}
+c
+{%- endset -%}
+{{ html_classes(class_a, {(class_c): true})}}
 --DATA--
 return []
 --EXPECT--
 a b d f 0
-a b
+a c

--- a/Tests/Fixtures/html_classes_with_unsupported_arg.test
+++ b/Tests/Fixtures/html_classes_with_unsupported_arg.test
@@ -5,4 +5,4 @@
 --DATA--
 return []
 --EXCEPTION--
-Twig\Error\RuntimeError: The "html_classes" function argument 0 should be either a string or an array, got "bool" in "index.twig" at line 2.
+Twig\Error\RuntimeError: The "html_classes" function argument 0 should be either a string, an instance of Stringable or an array, got "bool" in "index.twig" at line 2.

--- a/Tests/Fixtures/html_classes_with_unsupported_key.test
+++ b/Tests/Fixtures/html_classes_with_unsupported_key.test
@@ -5,4 +5,4 @@
 --DATA--
 return []
 --EXCEPTION--
-Twig\Error\RuntimeError: The "html_classes" function argument 0 (key 0) should be a string, got "int" in "index.twig" at line 2.
+Twig\Error\RuntimeError: The "html_classes" function argument 0 (key 0) should be a string or an instance of Stringable, got "int" in "index.twig" at line 2.


### PR DESCRIPTION
Recent changes broke a lot of my Twig code.

Would be nice to add support for `Stringable` (mostly `Twig\Markup`).